### PR TITLE
Added `robot_localization` as required dependency

### DIFF
--- a/outdoor_waypoint_nav/CMakeLists.txt
+++ b/outdoor_waypoint_nav/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   roslib
   roslaunch
+  robot_localization
 )
 
 catkin_package()


### PR DESCRIPTION
I believe robot_localization is required as a dependency due to this error below:
```
CMakeFiles/plot_gps_waypoints.dir/src/plot_gps_waypoints.cpp.o: In function `RobotLocalization::NavsatConversions::LLtoUTM(double, double, double&, double&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, double&)':
plot_gps_waypoints.cpp:(.text+0x64): undefined reference to `GeographicLib::UTMUPS::Forward(double, double, int&, bool&, double&, double&, double&, double&, int, bool)'
plot_gps_waypoints.cpp:(.text+0xa1): undefined reference to `GeographicLib::MGRS::Forward(int, bool, double, double, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)'
collect2: error: ld returned 1 exit status
outdoor_waypoint_nav/CMakeFiles/plot_gps_waypoints.dir/build.make:122: recipe for target '/home/mohsen/Source/husky/devel/lib/outdoor_waypoint_nav/plot_gps_waypoints' failed
make[2]: *** [/home/mohsen/Source/husky/devel/lib/outdoor_waypoint_nav/plot_gps_waypoints] Error 1
CMakeFiles/Makefile2:1151: recipe for target 'outdoor_waypoint_nav/CMakeFiles/plot_gps_waypoints.dir/all' failed
make[1]: *** [outdoor_waypoint_nav/CMakeFiles/plot_gps_waypoints.dir/all] Error 
```